### PR TITLE
Remove fpm_logfile from logrotate script

### DIFF
--- a/templates/default/php-fpm.logrotate.erb
+++ b/templates/default/php-fpm.logrotate.erb
@@ -1,4 +1,4 @@
-<%= node['php']['fpm_logfile'] %> <%= node['php']['fpm_log_dir'] %>/*.log {
+<%= node['php']['fpm_log_dir'] %>/*.log {
 	rotate 4
 	weekly
 	copytruncate


### PR DESCRIPTION
The default location of `fpm_logfile` on all operating systems is inside `fpm_log_dir`. This causes logrotate to emit a warning every time:

```
/etc/cron.daily/logrotate:
error: php5-fpm:1 duplicate log entry for /var/log/php5-fpm/fpm-master.log
error: found error in /var/log/php5-fpm/fpm-master.log /var/log/php5-fpm/*.log , skipping
```
