### PR TITLE
Change apc settings to variables

### DIFF
--- a/attributes/apc.rb
+++ b/attributes/apc.rb
@@ -21,5 +21,5 @@
 
 default['php']['apc']['shm_size'] = '128M'
 default['php']['apc']['local_size'] = '128M'
-default['php']['apc']['apc_ttl'] = '7200'
+default['php']['apc']['ttl'] = '7200'
 default['php']['apc']['user_ttl'] = '7200'

--- a/templates/default/apc.ini.erb
+++ b/templates/default/apc.ini.erb
@@ -23,7 +23,7 @@ apc.rfc1867_prefix = "upload_"
 apc.shm_segments = 1
 apc.shm_size = <%= node['php']['apc']['shm_size'] %>
 apc.stat = 1
-apc.ttl = <%= node['php']['apc']['apc_ttl'] %>
+apc.ttl = <%= node['php']['apc']['ttl'] %>
 apc.user_ttl = <%= node['php']['apc']['user_ttl'] %>
 apc.write_lock = 1
 apc.optimization = 0


### PR DESCRIPTION
Adds apc.ttl and apc.user_ttl as variables instead of hard coded values
