### PR TITLE
Run apt-get update before install

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -27,6 +27,11 @@ pkgs = value_for_platform_family(
 
 include_recipe 'yumrepo::atomic' if platform_family?('rhel')
 
+# Make sure the Apt cache is updated
+if platform_family?('debian')
+  resources(:execute => 'apt-get update').run_action(:run)
+end
+
 # Run the package installation at compile time
 pkgs.each do |pkg|
   package pkg do
@@ -82,7 +87,7 @@ template '/etc/cron.d/php5' do
   owner 'root'
   group 'root'
   variables({
-    :maxlifetime_script => platform_family?('rhel') ? '/usr/local/bin/php-maxlifetime' : '/usr/lib/php5/maxlifetime'  
+    :maxlifetime_script => platform_family?('rhel') ? '/usr/local/bin/php-maxlifetime' : '/usr/lib/php5/maxlifetime'
   })
   mode 00644
 end


### PR DESCRIPTION
Since the release of 5.4.6-1ubuntu1.3 this cookbook fails installation because apt is not updated before php gets installed. It tries to install revision 1.2 first but fails near the end because of missing dependencies. This fixes it for Debian-based operating systems. Don't know if RHEL-based systems need a similar fix.
