### PR TITLE
Add missing include recipe for apt update

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -26,6 +26,7 @@ pkgs = value_for_platform_family(
 )
 
 include_recipe 'yumrepo::atomic' if platform_family?('rhel')
+include_recipe 'apt' if platform_family?('debian')
 
 # Make sure the Apt cache is updated
 if platform_family?('debian')


### PR DESCRIPTION
I get the following exception since this commit 348020ce104c59e6caaaa1e5981c33e6f3817202 :

```
Chef::Exceptions::ResourceNotFound
----------------------------------
Cannot find a resource matching execute[apt-get update] (did you define it first?)
```

I think an include_recipe is missing to use apt resources.
