### PR TITLE
More accurate detection of pecl package vs pear packages

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -240,12 +240,12 @@ def pecl?
   @pecl ||= begin
     # search as a pear first since most 3rd party channels will report pears as pecls!
     search_cmd = "pear -d preferred_state=#{can_haz(@new_resource, 'preferred_state')} search#{expand_channel(can_haz(@new_resource, 'channel'))} #{@new_resource.package_name}"
-    if shell_out(search_cmd).stdout =~ /\.?Matched packages/i
+    if shell_out(search_cmd).stdout =~ /^\s*#{@new_resource.package_name}\s/i
       false
     else
       # fall back and search as a pecl
       search_cmd = "pecl -d preferred_state=#{can_haz(@new_resource, 'preferred_state')} search#{expand_channel(can_haz(@new_resource, 'channel'))} #{@new_resource.package_name}"
-      if shell_out(search_cmd).stdout =~ /\.?Matched packages/i
+      if shell_out(search_cmd).stdout =~ /^\s*#{@new_resource.package_name}\s/i
         true
       else
         false


### PR DESCRIPTION
The problem I ran into was with the OAuth PECL package. It was detected as a PEAR package because there is a HTTP_OAuth PEAR package. `pear search oauth` will match this package.
My changes bring a more accurate detection of PEAR vs PECL packages.
