### PR TITLE
Syntax error in php-maxlifetime template

### DIFF
--- a/templates/default/php-maxlifetime.sh.erb
+++ b/templates/default/php-maxlifetime.sh.erb
@@ -8,7 +8,6 @@ if which php >/dev/null 2>&1; then
         [ -z "$cur" ] && cur=0
         [ "$cur" -gt "$max" ] && max=$cur
     fi
-    done
 else
     for ini in /etc/php.ini /etc/php.d/*.ini; do
         cur=$(sed -n -e 's/^[[:space:]]*session.gc_maxlifetime[[:space:]]*=[[:space:]]*\([0-9]\+\).*$/\1/p' $ini 2>/dev/null || true);


### PR DESCRIPTION
Removed extraneous 'done' which was causing syntax errors in the php-maxlifetime.sh.erb template.
