### PR TITLE
Add fix for Ubuntu 14.04, apparently it fails if not using upstart.

### DIFF
--- a/recipes/fpm.rb
+++ b/recipes/fpm.rb
@@ -69,4 +69,6 @@ end
 # Since we do not have any pool files we do not attempt to start the service
 service pkgname do
   action :enable
+  supports [:start, :restart, :stop]
+  provider Chef::Provider::Service::Upstart if (node["platform"] == "ubuntu" && node["platform_version"].to_f >= 9.10)
 end


### PR DESCRIPTION
See for example: http://serverfault.com/questions/592319/restarting-php5-fpm-on-ubuntu-14-04-with-chef
