### PR TITLE
Default to UTC, let the user pick their timezone.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,7 +71,7 @@ default['php']['ini_settings'] = {
   'always_populate_raw_post_data' => 'Off',
   'cgi.fix_pathinfo' => '1',
   'upload_max_filesize' => '32M',
-  'date.timezone' => 'Europe/Athens',
+  'date.timezone' => 'UTC',
   'session.cookie_httponly' => '0'
 }
 


### PR DESCRIPTION
This sets a default of UTC, perhaps we can update the README to tell a user to set their timezone when needed.
